### PR TITLE
(chore) add FUNDING.yml for GitHub Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: alexey-pelykh


### PR DESCRIPTION
## Summary

- Add `.github/FUNDING.yml` to enable the Sponsor button on the repository

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)