### PR TITLE
(chore) add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Summary
+
+<!-- Brief description of what this PR does and why -->
+
+## Related Issues
+
+<!-- Reference issues: Closes #N -->
+
+## Changes
+
+<!-- List the key changes made -->
+
+## Testing
+
+<!-- Describe testing performed -->
+- [ ] `npm run lint` passes
+- [ ] `npm run test` passes
+- [ ] Tested on Linux or Windows (macOS does not support HeadlessExperimental)
+
+## Checklist
+
+- [ ] Code follows project conventions (ts-standard)
+- [ ] Commit messages use `(type) description` format
+- [ ] No issue numbers in commit messages (use `Closes #N` in this PR body)


### PR DESCRIPTION
## Summary

Add `.github/PULL_REQUEST_TEMPLATE.md` so new PRs auto-populate with consistent sections for summary, related issues, changes, testing, and checklist.

Closes #47

## Changes

- Added `.github/PULL_REQUEST_TEMPLATE.md` with sections matching project conventions from CLAUDE.md

## Testing

- No code changes; template is a static markdown file
- Verified file is placed at the standard GitHub path (`.github/PULL_REQUEST_TEMPLATE.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)