### PR TITLE
(fix) add concurrency control to GitHub Pages deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,10 @@ jobs:
   publish-github-pages:
     runs-on: ubuntu-24.04
 
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+
     permissions:
       contents: read
       pages: write


### PR DESCRIPTION
## Summary

- Add `concurrency` group to the `publish-github-pages` job to prevent deployment race conditions when multiple commits are pushed to `main` in quick succession
- Uses `cancel-in-progress: false` so deployments queue rather than cancel each other, ensuring the latest commit always gets deployed

Closes #53

## Test plan

- [ ] CI passes on this PR
- [ ] Push two commits to `main` in quick succession and verify the second deployment queues instead of failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)