### PR TITLE
(chore) migrate publish workflow to OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,12 +4,84 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
 jobs:
 
-  package:
+  validate:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
     env:
       PUPPETEER_VERSION: 24.6.1
+
+    steps:
+
+      - name: Validate semver tag
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if [[ ! "${TAG}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Tag '${TAG}' is not valid semver (expected X.Y.Z)"
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js LTS
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Get npm cache location
+        id: get-npm-cache
+        shell: bash
+        run: |
+          echo "NPM_CONFIG_CACHE=$(npm config get cache)" >> "$GITHUB_ENV"
+          echo "npm_config_cache=$(npm config get cache)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache npm packages
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.get-npm-cache.outputs.npm_config_cache }}
+          key: npm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: npm-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Cache Puppeteer
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/puppeteer/
+          key: puppeteer-${{ runner.os }}-${{ runner.arch }}-${{ env.PUPPETEER_VERSION }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test
+
+  publish:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    needs: validate
+
+    environment: npm-publish
+
+    permissions:
+      contents: read
+      id-token: write
+
+    env:
+      PUPPETEER_VERSION: 24.6.1
+
     steps:
 
       - name: Checkout
@@ -39,14 +111,16 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/puppeteer/
-          key: puppeteer-${{ runner.os }}-${{ runner.arch }}-${{ env.PUPPETEER_VERSION }}}
+          key: puppeteer-${{ runner.os }}-${{ runner.arch }}-${{ env.PUPPETEER_VERSION }}
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Publish
-        run: |
-          npm version "${GITHUB_REF##*/}" --allow-same-version --no-git-tag-version
-          npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Stamp version
+        run: npm version "${GITHUB_REF_NAME}" --allow-same-version --no-git-tag-version
+
+      - name: Dry-run publish
+        run: npm publish --dry-run
+
+      - name: Publish with provenance
+        run: npm publish --provenance

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,10 +104,15 @@ Do **not** add issue numbers to commit messages. Use `Closes #N` in PR body inst
 ## Release Process
 
 1. Ensure `main` is green
-2. Create GitHub Release (tag = version, e.g. `1.13.0`)
-3. Publish workflow stamps version from tag and runs `npm publish`
+2. Create GitHub Release (tag = semver version, e.g. `1.13.0`)
+3. Publish workflow validates tag, runs lint + test, then publishes with provenance
 
-**Required secrets**: `NPM_TOKEN`, `CODECOV_TOKEN`
+**Publishing**: Uses OIDC trusted publishing (no `NPM_TOKEN`). The `npm-publish` GitHub environment
+provides deployment protection. Provenance attestation links the published package to its source commit.
+
+**Required secrets**: `CODECOV_TOKEN`
+
+**Required environments**: `npm-publish` (with deployment protection rules)
 
 ## Platform Constraints
 
@@ -135,7 +140,7 @@ When a new puppeteer version is released, a single atomic commit updates 4 files
 
 ### 3. `.github/workflows/publish.yml`
 
-- Update `PUPPETEER_VERSION` env var to new version
+- Update `PUPPETEER_VERSION` env var in both `validate` and `publish` jobs to new version
 
 ### 4. `package-lock.json`
 


### PR DESCRIPTION
## Summary

- Replace `NPM_TOKEN` secret-based auth with OIDC trusted publishing (`id-token: write`)
- Add `--provenance` flag for Sigstore attestation linking package to source commit
- Add `npm-publish` GitHub environment with deployment protection
- Add explicit `permissions: contents: read` at workflow level
- Add `concurrency: { group: release, cancel-in-progress: false }`
- Add `timeout-minutes: 15` to both jobs
- Add `npm publish --dry-run` verification before actual publish
- Add semver tag format validation (`X.Y.Z`)
- Split into `validate` (lint + test) and `publish` jobs — publish only runs after validation passes
- Fix extra `}` typo in Puppeteer cache key
- Update CLAUDE.md release process documentation

## Setup required

Before the next release, configure:
1. **npm**: Package → Settings → Publishing access → Add GitHub Actions as trusted publisher (repo: `alexey-pelykh/puppeteer-capture`, environment: `npm-publish`)
2. **GitHub**: Settings → Environments → Create `npm-publish` environment with appropriate deployment protection rules
3. **GitHub**: The `NPM_TOKEN` repo secret can be removed after verifying OIDC publishing works

## Test plan

- [ ] Verify CI passes (lint, test)
- [ ] Create `npm-publish` environment on GitHub
- [ ] Configure npm trusted publishing for the package
- [ ] Test with a release to confirm OIDC auth + provenance work end-to-end
- [ ] Verify provenance badge appears on npmjs.com package page
- [ ] Remove `NPM_TOKEN` secret after successful publish

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)