### PR TITLE
(fix) duplicate null-check in _start() — probable copy-paste bug

### DIFF
--- a/src/PuppeteerCaptureBase.ts
+++ b/src/PuppeteerCaptureBase.ts
@@ -141,8 +141,8 @@ export abstract class PuppeteerCaptureBase extends EventEmitter implements Puppe
     if (options.waitForFirstFrame == null) {
       throw new Error('options.waitForFirstFrame can not be null or undefined')
     }
-    if (options.waitForFirstFrame == null) {
-      throw new Error('options.waitForFirstFrame can not be null or undefined')
+    if (options.dropCapturedFrames == null) {
+      throw new Error('options.dropCapturedFrames can not be null or undefined')
     }
 
     if (this._page == null) {


### PR DESCRIPTION
## Summary
- Fix copy-paste bug in `PuppeteerCaptureBase._start()` where the second null-check validated `waitForFirstFrame` again instead of `dropCapturedFrames`
- The `dropCapturedFrames` option was used at line 192 with a non-null assertion (`!`) but was never validated, which could cause unexpected behavior if the option were somehow nullish

## Test plan
- [ ] Lint passes (`npm run lint`)
- [ ] Build passes (`npm run build`)
- [ ] Existing tests pass in CI (Ubuntu, Windows)
- [ ] Integration tests pass across all puppeteer versions

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)