### PR TITLE
(imp) add top-level permissions block to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+permissions:
+  contents: read
+
 jobs:
 
   build:
@@ -161,7 +164,6 @@ jobs:
 
     permissions:
       contents: read
-      packages: write
 
     steps:
 


### PR DESCRIPTION
## Summary

- Add top-level `permissions: contents: read` to `ci.yml`, restricting the default token scope for all jobs that don't declare their own permissions (`build`, `integration`)
- Remove unnecessary `packages: write` from the `github-pages` job — it only builds HTML and uploads a pages artifact

Closes #68

## Test plan

- [ ] CI workflow runs successfully with the restricted permissions
- [ ] GitHub Pages build and deploy still work correctly
- [ ] Integration tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)