### PR TITLE
(fix) support repeated start/stop capture cycles

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -62,10 +62,6 @@ await page.setViewport({
 })
 ```
 
-### Multiple `start()`/`stop()` fail
-
-It's unclear why, yet after disabling and re-enabling the capture, callbacks from browser stop arriving.
-
 ### Time-related functions are affected
 
 The following functions have to be overridden with injected versions:

--- a/src/PuppeteerCaptureViaHeadlessExperimental.test.ts
+++ b/src/PuppeteerCaptureViaHeadlessExperimental.test.ts
@@ -72,28 +72,28 @@ test('that capture works in headless mode', async () => {
   expect(capture.capturedFrames).toBeGreaterThan(1)
 })
 
-// test('that capture works repeatedly in headless mode', async () => {
-//   browser = await launch({
-//     executablePath: executablePath({ headless: 'shell' }),
-//     args: PUPPETEER_LAUNCH_ARGS
-//   })
-//   const page = await browser.newPage()
-//   const capture = new PuppeteerCaptureViaHeadlessExperimental()
-//   await capture.attach(page)
-//   await page.goto('about:blank')
+test('that capture works repeatedly in headless mode', async () => {
+  browser = await launch({
+    executablePath: executablePath({ headless: 'shell' }),
+    args: PUPPETEER_LAUNCH_ARGS
+  })
+  const page = await browser.newPage()
+  const capture = new PuppeteerCaptureViaHeadlessExperimental()
+  await capture.attach(page)
+  await page.goto('about:blank')
 
-//   const stream1 = new PassThrough()
-//   await capture.start(stream1)
-//   await capture.waitForTimeout(32)
-//   await capture.stop()
-//   expect(capture.capturedFrames).toBeGreaterThan(1)
+  const stream1 = new PassThrough()
+  await capture.start(stream1)
+  await capture.waitForTimeout(32)
+  await capture.stop()
+  expect(capture.capturedFrames).toBeGreaterThan(1)
 
-//   const stream2 = new PassThrough()
-//   await capture.start(stream2)
-//   await capture.waitForTimeout(32)
-//   await capture.stop()
-//   expect(capture.capturedFrames).toBeGreaterThan(1)
-// })
+  const stream2 = new PassThrough()
+  await capture.start(stream2)
+  await capture.waitForTimeout(32)
+  await capture.stop()
+  expect(capture.capturedFrames).toBeGreaterThan(1)
+})
 
 test('that capture works with custom viewport size', async () => {
   browser = await launch({

--- a/src/PuppeteerCaptureViaHeadlessExperimental.ts
+++ b/src/PuppeteerCaptureViaHeadlessExperimental.ts
@@ -46,6 +46,7 @@ export class PuppeteerCaptureViaHeadlessExperimental extends PuppeteerCaptureBas
   protected readonly _onSessionDisconnected: () => void
   protected _session: PuppeteerCDPSession | null
   protected _onNewDocumentScript: Protocol.Page.ScriptIdentifier | null
+  protected _frameTimeTicks: number
 
   public constructor (options?: PuppeteerCaptureOptions) {
     super(options)
@@ -58,6 +59,7 @@ export class PuppeteerCaptureViaHeadlessExperimental extends PuppeteerCaptureBas
 
     this._session = null
     this._onNewDocumentScript = null
+    this._frameTimeTicks = 0
 
     if (process.platform === 'darwin') {
       throw new Error('MacOS is not supported by HeadlessExperimental.BeginFrame')
@@ -72,6 +74,8 @@ export class PuppeteerCaptureViaHeadlessExperimental extends PuppeteerCaptureBas
 
   protected override async _attach (page: PuppeteerPage): Promise<void> {
     PuppeteerCaptureViaHeadlessExperimental.validateBrowserArgs(page.browser())
+
+    this._frameTimeTicks = 0
 
     const session = await page.createCDPSession()
 
@@ -121,12 +125,13 @@ export class PuppeteerCaptureViaHeadlessExperimental extends PuppeteerCaptureBas
 
   protected doRequestFrameCapture (page: PuppeteerPage, session: PuppeteerCDPSession): void {
     const captureTimestamp = this._captureTimestamp
+    const frameTimeTicks = this._frameTimeTicks
     const frameInterval = this._frameInterval
     this._frameBeingCaptured = Promise.all(page.frames().map(async (frame) => {
       await frame.evaluate(`${this._injected}.process(${captureTimestamp})`)
     })).then(async () => {
       return await session.send('HeadlessExperimental.beginFrame', {
-        frameTimeTicks: captureTimestamp,
+        frameTimeTicks,
         interval: frameInterval,
         noDisplayUpdates: false,
         screenshot: { format: 'png' }
@@ -148,6 +153,7 @@ export class PuppeteerCaptureViaHeadlessExperimental extends PuppeteerCaptureBas
 
         if (this._isCapturing) {
           this._captureTimestamp = captureTimestamp + frameInterval
+          this._frameTimeTicks = frameTimeTicks + frameInterval
           setTimeout(this._requestFrameCapture, 0)
         }
       },


### PR DESCRIPTION
## Summary

- **Root cause**: `HeadlessExperimental.beginFrame` requires monotonically increasing `frameTimeTicks`. Previously this was tied to `_captureTimestamp` which resets to 0 on each `start()`, causing Chrome to stop returning screenshot data on the second capture session.
- **Fix**: Decouple `frameTimeTicks` from `_captureTimestamp` by introducing a separate `_frameTimeTicks` counter that increases monotonically across start/stop cycles and only resets on `attach()` (new CDP session).
- Re-enable the previously commented-out repeated capture test
- Remove the "Multiple start/stop fail" entry from KNOWN_ISSUES.md

## Test plan

- [ ] Re-enabled test `that capture works repeatedly in headless mode` passes in CI (Linux)
- [ ] Existing tests continue to pass (no regression from decoupling frameTimeTicks)
- [ ] Build and lint pass

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)