### PR TITLE
Pin GitHub Actions to SHA digests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,10 +36,10 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           registry-url: https://registry.npmjs.org
           node-version: ${{ matrix.node-version }}
@@ -52,7 +52,7 @@ jobs:
           echo "npm_config_cache=$(npm config get cache)" >> "$GITHUB_OUTPUT"
 
       - name: Cache npm packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.get-npm-cache.outputs.npm_config_cache }}
           key: npm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/package-lock.json') }}
@@ -64,7 +64,7 @@ jobs:
         run: echo "path=$(node -e "console.log(require('path').join(require('os').homedir(), '.cache', 'puppeteer'))")" >> "$GITHUB_OUTPUT"
 
       - name: Cache Puppeteer
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.pptr-cache.outputs.path }}
           key: puppeteer-${{ runner.os }}-${{ runner.arch }}-${{ env.PUPPETEER_VERSION }}
@@ -79,7 +79,7 @@ jobs:
         run: npm run test
 
       - name: Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
@@ -108,10 +108,10 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Use Node.js LTS
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           registry-url: https://registry.npmjs.org
           node-version: lts/*
@@ -124,7 +124,7 @@ jobs:
           echo "npm_config_cache=$(npm config get cache)" >> "$GITHUB_OUTPUT"
 
       - name: Cache npm packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.get-npm-cache.outputs.npm_config_cache }}
           key: npm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/package-lock.json') }}
@@ -136,7 +136,7 @@ jobs:
         run: echo "path=$(node -e "console.log(require('path').join(require('os').homedir(), '.cache', 'puppeteer'))")" >> "$GITHUB_OUTPUT"
 
       - name: Cache Puppeteer
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.pptr-cache.outputs.path }}
           key: puppeteer-${{ runner.os }}-${{ runner.arch }}-${{ matrix.puppeteer-version }}
@@ -168,10 +168,10 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Git Hub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Build GitHub Pages
         run: |
@@ -183,7 +183,7 @@ jobs:
             -o build/gh-pages/index.html gh-pages/metadata.md README.md
 
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: build/gh-pages
 
@@ -212,8 +212,8 @@ jobs:
     steps:
 
       - name: Set up Git Hub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
 
       - name: Publish GitHub Pages
         id: publish-github-pages
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,10 +31,10 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Use Node.js LTS
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: lts/*
 
@@ -46,14 +46,14 @@ jobs:
           echo "npm_config_cache=$(npm config get cache)" >> "$GITHUB_OUTPUT"
 
       - name: Cache npm packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.get-npm-cache.outputs.npm_config_cache }}
           key: npm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: npm-${{ runner.os }}-${{ runner.arch }}
 
       - name: Cache Puppeteer
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/puppeteer/
           key: puppeteer-${{ runner.os }}-${{ runner.arch }}-${{ env.PUPPETEER_VERSION }}
@@ -85,10 +85,10 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Use Node.js LTS
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           registry-url: https://registry.npmjs.org
           node-version: lts/*
@@ -101,14 +101,14 @@ jobs:
           echo "npm_config_cache=$(npm config get cache)" >> "$GITHUB_OUTPUT"
 
       - name: Cache npm packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.get-npm-cache.outputs.npm_config_cache }}
           key: npm-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: npm-${{ runner.os }}-${{ runner.arch }}
 
       - name: Cache Puppeteer
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/puppeteer/
           key: puppeteer-${{ runner.os }}-${{ runner.arch }}-${{ env.PUPPETEER_VERSION }}


### PR DESCRIPTION
## Summary

- Pin all 7 distinct GitHub Actions across `ci.yml` and `publish.yml` to immutable SHA digests instead of mutable version tags
- Each pinned reference includes a version comment (`# v4`, `# v5`, etc.) for readability
- Mitigates supply chain risk from tag mutation or compromised maintainer accounts (especially relevant for third-party `codecov/codecov-action`)

**Actions pinned:**
| Action | Tag | SHA |
|--------|-----|-----|
| `actions/checkout` | v4 | `34e11487` |
| `actions/setup-node` | v4 | `49933ea5` |
| `actions/cache` | v4 | `0057852b` |
| `codecov/codecov-action` | v5 | `671740ac` |
| `actions/configure-pages` | v5 | `983d7736` |
| `actions/upload-pages-artifact` | v3 | `56afc609` |
| `actions/deploy-pages` | v4 | `d6db9016` |

Closes #69

## Test plan

- [ ] CI workflow runs successfully (build, integration, github-pages jobs)
- [ ] Verify each action resolves to the expected version

🤖 Generated with [Claude Code](https://claude.com/claude-code)