### PR TITLE
Add unit tests — inverted test pyramid

### DIFF
--- a/src/PuppeteerCaptureBase.test.ts
+++ b/src/PuppeteerCaptureBase.test.ts
@@ -1,0 +1,443 @@
+import { PassThrough } from 'stream'
+import { PuppeteerCaptureBase } from './PuppeteerCaptureBase'
+
+jest.mock('which')
+jest.mock('fluent-ffmpeg', () => {
+  const mockStream: any = {
+    input: jest.fn().mockReturnThis(),
+    inputFormat: jest.fn().mockReturnThis(),
+    inputFPS: jest.fn().mockReturnThis(),
+    output: jest.fn().mockReturnThis(),
+    outputFPS: jest.fn().mockReturnThis(),
+    size: jest.fn().mockReturnThis(),
+    outputFormat: jest.fn().mockReturnThis(),
+    withVideoCodec: jest.fn().mockReturnThis(),
+    outputOption: jest.fn().mockReturnThis(),
+    run: jest.fn(),
+    once: jest.fn().mockReturnThis(),
+    off: jest.fn().mockReturnThis(),
+    on: jest.fn().mockReturnThis(),
+    removeAllListeners: jest.fn().mockReturnThis(),
+    emit: jest.fn().mockReturnThis()
+  }
+
+  mockStream.run.mockImplementation(() => {
+    const startCall = mockStream.once.mock.calls.find(
+      (call: any[]) => call[0] === 'start'
+    )
+    if (startCall != null) {
+      startCall[1]()
+    }
+  })
+
+  const factory: any = jest.fn(() => mockStream)
+  return {
+    __esModule: true,
+    default: factory,
+    setFfmpegPath: jest.fn(),
+    _mockStream: mockStream
+  }
+})
+
+class TestCapture extends PuppeteerCaptureBase {}
+
+beforeEach(() => {
+  const ffmpegMod = require('fluent-ffmpeg') // eslint-disable-line @typescript-eslint/no-var-requires
+  const mockStream = ffmpegMod._mockStream
+  for (const key of Object.keys(mockStream)) {
+    if (typeof mockStream[key]?.mockClear === 'function') {
+      mockStream[key].mockClear()
+    }
+  }
+  // Re-setup chain returns after clearing
+  mockStream.input.mockReturnThis()
+  mockStream.inputFormat.mockReturnThis()
+  mockStream.inputFPS.mockReturnThis()
+  mockStream.output.mockReturnThis()
+  mockStream.outputFPS.mockReturnThis()
+  mockStream.size.mockReturnThis()
+  mockStream.outputFormat.mockReturnThis()
+  mockStream.withVideoCodec.mockReturnThis()
+  mockStream.outputOption.mockReturnThis()
+  mockStream.once.mockReturnThis()
+  mockStream.off.mockReturnThis()
+  mockStream.on.mockReturnThis()
+  mockStream.removeAllListeners.mockReturnThis()
+  mockStream.emit.mockReturnThis()
+  // Re-setup run to trigger 'start' callback
+  mockStream.run.mockImplementation(() => {
+    const startCall = mockStream.once.mock.calls.find(
+      (call: any[]) => call[0] === 'start'
+    )
+    if (startCall != null) {
+      startCall[1]()
+    }
+  })
+  ffmpegMod.default.mockClear()
+})
+
+function createMockPage (closed = false): any {
+  return {
+    isClosed: jest.fn().mockReturnValue(closed),
+    once: jest.fn().mockReturnThis(),
+    off: jest.fn().mockReturnThis(),
+    on: jest.fn().mockReturnThis()
+  }
+}
+
+describe('constructor', () => {
+  test('uses default options', () => {
+    const capture = new TestCapture()
+    expect(capture.page).toBeNull()
+    expect(capture.isCapturing).toBe(false)
+    expect(capture.captureTimestamp).toBe(0)
+    expect(capture.capturedFrames).toBe(0)
+    expect(capture.recordedFrames).toBe(0)
+    expect(capture.dropCapturedFrames).toBe(false)
+  })
+
+  test('default fps is 60', () => {
+    const capture = new TestCapture()
+    expect(capture['_frameInterval']).toBeCloseTo(1000 / 60) // eslint-disable-line @typescript-eslint/dot-notation
+  })
+
+  test('accepts custom fps', () => {
+    const capture = new TestCapture({ fps: 30 })
+    expect(capture['_frameInterval']).toBeCloseTo(1000 / 30) // eslint-disable-line @typescript-eslint/dot-notation
+  })
+
+  test('throws when fps is null', () => {
+    expect(() => new TestCapture({ fps: null as any })).toThrow(
+      'options.fps needs to be set'
+    )
+  })
+
+  test('throws when fps is undefined', () => {
+    expect(() => new TestCapture({ fps: undefined })).toThrow(
+      'options.fps needs to be set'
+    )
+  })
+
+  test('throws when fps is negative', () => {
+    expect(() => new TestCapture({ fps: -1 })).toThrow(
+      'options.fps can not be set to -1'
+    )
+  })
+
+  test('accepts fps of 0', () => {
+    const capture = new TestCapture({ fps: 0 })
+    expect(capture['_frameInterval']).toBe(Infinity) // eslint-disable-line @typescript-eslint/dot-notation
+  })
+})
+
+describe('attach', () => {
+  test('sets the page', async () => {
+    const capture = new TestCapture()
+    const page = createMockPage()
+    await capture.attach(page)
+    expect(capture.page).toBe(page)
+  })
+
+  test('throws when already attached', async () => {
+    const capture = new TestCapture()
+    await capture.attach(createMockPage())
+    await expect(capture.attach(createMockPage())).rejects.toThrow(
+      'Already attached to a page'
+    )
+  })
+})
+
+describe('detach', () => {
+  test('clears the page', async () => {
+    const capture = new TestCapture()
+    await capture.attach(createMockPage())
+    await capture.detach()
+    expect(capture.page).toBeNull()
+  })
+
+  test('throws when not attached', async () => {
+    const capture = new TestCapture()
+    await expect(capture.detach()).rejects.toThrow(
+      'Already detached from a page'
+    )
+  })
+
+  test('allows re-attach after detach', async () => {
+    const capture = new TestCapture()
+    const page1 = createMockPage()
+    const page2 = createMockPage()
+    await capture.attach(page1)
+    await capture.detach()
+    await capture.attach(page2)
+    expect(capture.page).toBe(page2)
+  })
+})
+
+describe('start error paths', () => {
+  test('throws when not attached', async () => {
+    const capture = new TestCapture()
+    await expect(capture.start(new PassThrough())).rejects.toThrow(
+      'Not attached to a page'
+    )
+  })
+
+  test('throws when page is closed', async () => {
+    const capture = new TestCapture({ ffmpeg: '/mock/ffmpeg' })
+    await capture.attach(createMockPage(true))
+    await expect(capture.start(new PassThrough())).rejects.toThrow(
+      'Can not start capturing a closed page'
+    )
+  })
+
+  test('throws when capture is already in progress', async () => {
+    const capture = new TestCapture({ ffmpeg: '/mock/ffmpeg' })
+    await capture.attach(createMockPage())
+    capture['_isCapturing'] = true // eslint-disable-line @typescript-eslint/dot-notation
+    await expect(capture.start(new PassThrough())).rejects.toThrow(
+      'Capture is in progress'
+    )
+  })
+
+  test('throws when waitForFirstFrame is null', async () => {
+    const capture = new TestCapture({ ffmpeg: '/mock/ffmpeg' })
+    await capture.attach(createMockPage())
+    await expect(
+      capture.start(new PassThrough(), { waitForFirstFrame: null as any })
+    ).rejects.toThrow('options.waitForFirstFrame can not be null or undefined')
+  })
+
+  test('throws when dropCapturedFrames is null', async () => {
+    const capture = new TestCapture({ ffmpeg: '/mock/ffmpeg' })
+    await capture.attach(createMockPage())
+    await expect(
+      capture.start(new PassThrough(), { dropCapturedFrames: null as any })
+    ).rejects.toThrow('options.dropCapturedFrames can not be null or undefined')
+  })
+})
+
+describe('start', () => {
+  test('emits captureStarted', async () => {
+    const capture = new TestCapture({ ffmpeg: '/mock/ffmpeg' })
+    await capture.attach(createMockPage())
+
+    const handler = jest.fn()
+    capture.on('captureStarted', handler)
+    await capture.start(new PassThrough(), { waitForFirstFrame: false })
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(capture.isCapturing).toBe(true)
+  })
+
+  test('sets dropCapturedFrames from options', async () => {
+    const capture = new TestCapture({ ffmpeg: '/mock/ffmpeg' })
+    await capture.attach(createMockPage())
+    await capture.start(new PassThrough(), {
+      waitForFirstFrame: false,
+      dropCapturedFrames: true
+    })
+    expect(capture.dropCapturedFrames).toBe(true)
+  })
+
+  test('uses default start options', async () => {
+    const capture = new TestCapture({ ffmpeg: '/mock/ffmpeg' })
+    await capture.attach(createMockPage())
+    await capture.start(new PassThrough(), { waitForFirstFrame: false })
+    expect(capture.dropCapturedFrames).toBe(false)
+  })
+})
+
+describe('stop', () => {
+  test('rethrows stored error', async () => {
+    const capture = new TestCapture()
+    capture['_error'] = new Error('stored error') // eslint-disable-line @typescript-eslint/dot-notation
+    await expect(capture.stop()).rejects.toThrow('stored error')
+  })
+
+  test('clears stored error after rethrowing', async () => {
+    const capture = new TestCapture()
+    capture['_error'] = new Error('stored error') // eslint-disable-line @typescript-eslint/dot-notation
+    try { await capture.stop() } catch {}
+    expect(capture['_error']).toBeNull() // eslint-disable-line @typescript-eslint/dot-notation
+  })
+
+  test('emits captureStopped', async () => {
+    const capture = new TestCapture({ ffmpeg: '/mock/ffmpeg' })
+    await capture.attach(createMockPage())
+
+    // Set up minimal state for _stop to succeed
+    capture['_isCapturing'] = true // eslint-disable-line @typescript-eslint/dot-notation
+
+    const handler = jest.fn()
+    capture.on('captureStopped', handler)
+    await capture.stop()
+
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(capture.isCapturing).toBe(false)
+  })
+})
+
+describe('waitForTimeout', () => {
+  test('throws when not capturing', async () => {
+    const capture = new TestCapture()
+    await expect(capture.waitForTimeout(100)).rejects.toThrow(
+      'Can not wait for timeout while not capturing'
+    )
+  })
+})
+
+describe('dropCapturedFrames', () => {
+  test('getter returns current value', () => {
+    const capture = new TestCapture()
+    expect(capture.dropCapturedFrames).toBe(false)
+  })
+
+  test('setter updates value', () => {
+    const capture = new TestCapture()
+    capture.dropCapturedFrames = true
+    expect(capture.dropCapturedFrames).toBe(true)
+  })
+})
+
+describe('onFrameCaptured', () => {
+  test('emits frameCaptured event', async () => {
+    const capture = new TestCapture()
+    const handler = jest.fn()
+    capture.on('frameCaptured', handler)
+
+    const data = Buffer.from('frame-data')
+    await capture['onFrameCaptured'](100, data) // eslint-disable-line @typescript-eslint/dot-notation
+
+    expect(handler).toHaveBeenCalledWith(0, 100, data)
+  })
+
+  test('increments capturedFrames', async () => {
+    const capture = new TestCapture()
+    await capture['onFrameCaptured'](0, Buffer.from('a')) // eslint-disable-line @typescript-eslint/dot-notation
+    await capture['onFrameCaptured'](16, Buffer.from('b')) // eslint-disable-line @typescript-eslint/dot-notation
+    expect(capture.capturedFrames).toBe(2)
+  })
+
+  test('emits frameRecorded when not dropping frames', async () => {
+    const capture = new TestCapture()
+    capture['_framesStream'] = new PassThrough() // eslint-disable-line @typescript-eslint/dot-notation
+
+    const handler = jest.fn()
+    capture.on('frameRecorded', handler)
+
+    const data = Buffer.from('frame-data')
+    await capture['onFrameCaptured'](100, data) // eslint-disable-line @typescript-eslint/dot-notation
+
+    expect(handler).toHaveBeenCalledWith(0, 100, data)
+    expect(capture.recordedFrames).toBe(1)
+  })
+
+  test('skips frameRecorded when dropping frames', async () => {
+    const capture = new TestCapture()
+    capture['_framesStream'] = new PassThrough() // eslint-disable-line @typescript-eslint/dot-notation
+    capture.dropCapturedFrames = true
+
+    const handler = jest.fn()
+    capture.on('frameRecorded', handler)
+
+    await capture['onFrameCaptured'](100, Buffer.from('frame-data')) // eslint-disable-line @typescript-eslint/dot-notation
+
+    expect(handler).not.toHaveBeenCalled()
+    expect(capture.recordedFrames).toBe(0)
+    expect(capture.capturedFrames).toBe(1)
+  })
+})
+
+describe('onFrameCaptureFailed', () => {
+  test('emits frameCaptureFailed and stores error', async () => {
+    const capture = new TestCapture({ ffmpeg: '/mock/ffmpeg' })
+    await capture.attach(createMockPage())
+    capture['_isCapturing'] = true // eslint-disable-line @typescript-eslint/dot-notation
+
+    const handler = jest.fn()
+    capture.on('frameCaptureFailed', handler)
+
+    const error = new Error('capture failed')
+    await capture['onFrameCaptureFailed'](error) // eslint-disable-line @typescript-eslint/dot-notation
+
+    expect(handler).toHaveBeenCalledWith(error)
+    expect(capture['_error']).toBe(error) // eslint-disable-line @typescript-eslint/dot-notation
+  })
+})
+
+describe('onPageClose', () => {
+  test('stores Page was closed error', () => {
+    const capture = new TestCapture()
+    capture['_page'] = createMockPage() // eslint-disable-line @typescript-eslint/dot-notation
+    capture['onPageClose']() // eslint-disable-line @typescript-eslint/dot-notation
+    expect(capture['_error']).toBeInstanceOf(Error) // eslint-disable-line @typescript-eslint/dot-notation
+    expect(capture['_error'].message).toBe('Page was closed') // eslint-disable-line @typescript-eslint/dot-notation
+  })
+})
+
+describe('findFfmpeg', () => {
+  const originalFfmpeg = process.env.FFMPEG
+
+  afterEach(() => {
+    if (originalFfmpeg === undefined) {
+      delete process.env.FFMPEG
+    } else {
+      process.env.FFMPEG = originalFfmpeg
+    }
+  })
+
+  test('returns FFMPEG env var when set', async () => {
+    process.env.FFMPEG = '/custom/ffmpeg'
+    const result = await (PuppeteerCaptureBase as any).findFfmpeg()
+    expect(result).toBe('/custom/ffmpeg')
+  })
+
+  test('returns which result when env var is not set', async () => {
+    delete process.env.FFMPEG
+    const which = require('which') as jest.Mock // eslint-disable-line @typescript-eslint/no-var-requires
+    which.mockResolvedValueOnce('/usr/bin/ffmpeg')
+    const result = await (PuppeteerCaptureBase as any).findFfmpeg()
+    expect(result).toBe('/usr/bin/ffmpeg')
+  })
+
+  test('falls back to @ffmpeg-installer when which fails', async () => {
+    delete process.env.FFMPEG
+    const which = require('which') as jest.Mock // eslint-disable-line @typescript-eslint/no-var-requires
+    which.mockRejectedValueOnce(new Error('not found'))
+    const result = await (PuppeteerCaptureBase as any).findFfmpeg()
+    expect(typeof result).toBe('string')
+    expect(result.length).toBeGreaterThan(0)
+  })
+
+  test('throws when no ffmpeg is available', async () => {
+    delete process.env.FFMPEG
+
+    jest.resetModules()
+    jest.doMock('which', () => jest.fn().mockRejectedValue(new Error('not found')))
+    jest.doMock('@ffmpeg-installer/ffmpeg', () => { throw new Error('Cannot find module') })
+
+    const { PuppeteerCaptureBase: FreshBase } = require('./PuppeteerCaptureBase') // eslint-disable-line @typescript-eslint/no-var-requires
+    await expect(FreshBase.findFfmpeg()).rejects.toThrow(
+      'ffmpeg not available'
+    )
+  })
+})
+
+describe('DEFAULT_OPTIONS', () => {
+  test('fps is 60', () => {
+    expect(PuppeteerCaptureBase.DEFAULT_OPTIONS.fps).toBe(60)
+  })
+
+  test('format is defined', () => {
+    expect(typeof PuppeteerCaptureBase.DEFAULT_OPTIONS.format).toBe('function')
+  })
+})
+
+describe('DEFAULT_START_OPTIONS', () => {
+  test('waitForFirstFrame is true', () => {
+    expect(PuppeteerCaptureBase.DEFAULT_START_OPTIONS.waitForFirstFrame).toBe(true)
+  })
+
+  test('dropCapturedFrames is false', () => {
+    expect(PuppeteerCaptureBase.DEFAULT_START_OPTIONS.dropCapturedFrames).toBe(false)
+  })
+})

--- a/src/PuppeteerCaptureFormat.test.ts
+++ b/src/PuppeteerCaptureFormat.test.ts
@@ -1,0 +1,38 @@
+import { MP4 } from './PuppeteerCaptureFormat'
+
+function createMockFfmpegCommand (): any {
+  const mock: any = {}
+  mock.outputFormat = jest.fn().mockReturnValue(mock)
+  mock.withVideoCodec = jest.fn().mockReturnValue(mock)
+  mock.outputOption = jest.fn().mockReturnValue(mock)
+  return mock
+}
+
+test('MP4() uses ultrafast preset and libx264 by default', async () => {
+  const format = MP4()
+  const ffmpeg = createMockFfmpegCommand()
+  await format(ffmpeg)
+  expect(ffmpeg.outputFormat).toHaveBeenCalledWith('mp4')
+  expect(ffmpeg.withVideoCodec).toHaveBeenCalledWith('libx264')
+  expect(ffmpeg.outputOption).toHaveBeenCalledWith('-preset ultrafast')
+  expect(ffmpeg.outputOption).toHaveBeenCalledWith('-movflags +frag_keyframe+separate_moof+omit_tfhd_offset+empty_moov')
+})
+
+test('MP4() uses custom preset', async () => {
+  const format = MP4('slow')
+  const ffmpeg = createMockFfmpegCommand()
+  await format(ffmpeg)
+  expect(ffmpeg.outputOption).toHaveBeenCalledWith('-preset slow')
+})
+
+test('MP4() uses custom video codec', async () => {
+  const format = MP4('ultrafast', 'libx265')
+  const ffmpeg = createMockFfmpegCommand()
+  await format(ffmpeg)
+  expect(ffmpeg.withVideoCodec).toHaveBeenCalledWith('libx265')
+})
+
+test('MP4() returns an async function', () => {
+  const format = MP4()
+  expect(typeof format).toBe('function')
+})

--- a/src/PuppeteerCaptureViaHeadlessExperimental.unit.test.ts
+++ b/src/PuppeteerCaptureViaHeadlessExperimental.unit.test.ts
@@ -1,0 +1,153 @@
+import { MissingHeadlessExperimentalRequiredArgs } from './MissingHeadlessExperimentalRequiredArgs'
+import { NotChromeHeadlessShell } from './NotChromeHeadlessShell'
+import { PuppeteerCaptureViaHeadlessExperimental } from './PuppeteerCaptureViaHeadlessExperimental'
+
+const originalPlatform = process.platform
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', { value: originalPlatform })
+})
+
+function createMockBrowser (spawnfile: string | undefined, spawnargs?: string[]): any {
+  return {
+    process: () => ({
+      spawnfile,
+      spawnargs: spawnargs ?? []
+    })
+  }
+}
+
+describe('constructor', () => {
+  test('throws on macOS', () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' })
+    expect(() => new PuppeteerCaptureViaHeadlessExperimental()).toThrow(
+      'MacOS is not supported by HeadlessExperimental.BeginFrame'
+    )
+  })
+
+  test('succeeds on linux', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+    expect(() => new PuppeteerCaptureViaHeadlessExperimental()).not.toThrow()
+  })
+
+  test('succeeds on win32', () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' })
+    expect(() => new PuppeteerCaptureViaHeadlessExperimental()).not.toThrow()
+  })
+
+  test('passes options to base class', () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' })
+    const capture = new PuppeteerCaptureViaHeadlessExperimental({ fps: 24 })
+    expect(capture['_frameInterval']).toBeCloseTo(1000 / 24) // eslint-disable-line @typescript-eslint/dot-notation
+  })
+})
+
+describe('validateBrowserArgs', () => {
+  test('throws NotChromeHeadlessShell when spawnfile is null', () => {
+    const browser = { process: () => ({ spawnfile: null, spawnargs: [] }) }
+    expect(() => {
+      (PuppeteerCaptureViaHeadlessExperimental as any).validateBrowserArgs(browser)
+    }).toThrow(NotChromeHeadlessShell)
+  })
+
+  test('throws NotChromeHeadlessShell when spawnfile is undefined', () => {
+    const browser = { process: () => ({ spawnfile: undefined, spawnargs: [] }) }
+    expect(() => {
+      (PuppeteerCaptureViaHeadlessExperimental as any).validateBrowserArgs(browser)
+    }).toThrow(NotChromeHeadlessShell)
+  })
+
+  test('throws NotChromeHeadlessShell for non-headless-shell binary', () => {
+    const browser = createMockBrowser('/usr/bin/chromium')
+    expect(() => {
+      (PuppeteerCaptureViaHeadlessExperimental as any).validateBrowserArgs(browser)
+    }).toThrow(NotChromeHeadlessShell)
+  })
+
+  test('throws NotChromeHeadlessShell with executable path in message', () => {
+    const browser = createMockBrowser('/usr/bin/chromium')
+    expect(() => {
+      (PuppeteerCaptureViaHeadlessExperimental as any).validateBrowserArgs(browser)
+    }).toThrow('Not chrome-headless-shell: /usr/bin/chromium')
+  })
+
+  test('throws NotChromeHeadlessShell when process returns null spawnfile', () => {
+    const browser = { process: () => null }
+    expect(() => {
+      (PuppeteerCaptureViaHeadlessExperimental as any).validateBrowserArgs(browser)
+    }).toThrow(NotChromeHeadlessShell)
+  })
+
+  test('throws MissingHeadlessExperimentalRequiredArgs when args are missing', () => {
+    const browser = createMockBrowser('/path/to/chrome-headless-shell', [])
+    expect(() => {
+      (PuppeteerCaptureViaHeadlessExperimental as any).validateBrowserArgs(browser)
+    }).toThrow(MissingHeadlessExperimentalRequiredArgs)
+  })
+
+  test('throws MissingHeadlessExperimentalRequiredArgs when some args are missing', () => {
+    const browser = createMockBrowser('/path/to/chrome-headless-shell', [
+      '--deterministic-mode'
+    ])
+    expect(() => {
+      (PuppeteerCaptureViaHeadlessExperimental as any).validateBrowserArgs(browser)
+    }).toThrow(MissingHeadlessExperimentalRequiredArgs)
+  })
+
+  test('throws MissingHeadlessExperimentalRequiredArgs when spawnargs is null', () => {
+    const browser = {
+      process: () => ({
+        spawnfile: '/path/to/chrome-headless-shell',
+        spawnargs: null
+      })
+    }
+    expect(() => {
+      (PuppeteerCaptureViaHeadlessExperimental as any).validateBrowserArgs(browser)
+    }).toThrow(MissingHeadlessExperimentalRequiredArgs)
+  })
+
+  test('succeeds with chrome-headless-shell and all required args', () => {
+    const browser = createMockBrowser(
+      '/path/to/chrome-headless-shell',
+      PuppeteerCaptureViaHeadlessExperimental.REQUIRED_ARGS
+    )
+    expect(() => {
+      (PuppeteerCaptureViaHeadlessExperimental as any).validateBrowserArgs(browser)
+    }).not.toThrow()
+  })
+
+  test('succeeds with additional args beyond required ones', () => {
+    const browser = createMockBrowser(
+      '/path/to/chrome-headless-shell',
+      ['--no-sandbox', ...PuppeteerCaptureViaHeadlessExperimental.REQUIRED_ARGS, '--disable-gpu']
+    )
+    expect(() => {
+      (PuppeteerCaptureViaHeadlessExperimental as any).validateBrowserArgs(browser)
+    }).not.toThrow()
+  })
+})
+
+describe('REQUIRED_ARGS', () => {
+  test('contains expected arguments', () => {
+    expect(PuppeteerCaptureViaHeadlessExperimental.REQUIRED_ARGS).toContain('--deterministic-mode')
+    expect(PuppeteerCaptureViaHeadlessExperimental.REQUIRED_ARGS).toContain('--enable-begin-frame-control')
+  })
+
+  test('is frozen (immutable)', () => {
+    expect(Array.isArray(PuppeteerCaptureViaHeadlessExperimental.REQUIRED_ARGS)).toBe(true)
+  })
+})
+
+describe('generateInjector', () => {
+  test('returns a string containing the fps value', () => {
+    const injector = (PuppeteerCaptureViaHeadlessExperimental as any).generateInjector(30)
+    expect(typeof injector).toBe('string')
+    expect(injector).toContain('30')
+  })
+
+  test('returns different injectors for different fps values', () => {
+    const injector30 = (PuppeteerCaptureViaHeadlessExperimental as any).generateInjector(30)
+    const injector60 = (PuppeteerCaptureViaHeadlessExperimental as any).generateInjector(60)
+    expect(injector30).not.toEqual(injector60)
+  })
+})

--- a/src/capture.test.ts
+++ b/src/capture.test.ts
@@ -1,0 +1,41 @@
+import { capture } from './capture'
+
+const mockAttach = jest.fn()
+jest.mock('./PuppeteerCaptureViaHeadlessExperimental', () => ({
+  PuppeteerCaptureViaHeadlessExperimental: jest.fn().mockImplementation(() => ({
+    attach: mockAttach
+  }))
+}))
+
+const { PuppeteerCaptureViaHeadlessExperimental } = require('./PuppeteerCaptureViaHeadlessExperimental') // eslint-disable-line @typescript-eslint/no-var-requires
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('capture() creates instance and attaches to page by default', async () => {
+  const mockPage = {} as any
+  await capture(mockPage)
+  expect(PuppeteerCaptureViaHeadlessExperimental).toHaveBeenCalledTimes(1)
+  expect(mockAttach).toHaveBeenCalledWith(mockPage)
+})
+
+test('capture() passes options to constructor', async () => {
+  const mockPage = {} as any
+  const options = { fps: 30 }
+  await capture(mockPage, options)
+  expect(PuppeteerCaptureViaHeadlessExperimental).toHaveBeenCalledWith(options)
+})
+
+test('capture() with attach: false does not attach', async () => {
+  const mockPage = {} as any
+  await capture(mockPage, { attach: false })
+  expect(PuppeteerCaptureViaHeadlessExperimental).toHaveBeenCalledTimes(1)
+  expect(mockAttach).not.toHaveBeenCalled()
+})
+
+test('capture() with attach: true attaches', async () => {
+  const mockPage = {} as any
+  await capture(mockPage, { attach: true })
+  expect(mockAttach).toHaveBeenCalledWith(mockPage)
+})

--- a/src/launch.test.ts
+++ b/src/launch.test.ts
@@ -1,0 +1,49 @@
+import { launch } from './launch'
+
+jest.mock('puppeteer-core', () => ({
+  __esModule: true,
+  default: { launch: jest.fn().mockResolvedValue({}) }
+}))
+
+jest.mock('./PuppeteerCaptureViaHeadlessExperimental', () => ({
+  PuppeteerCaptureViaHeadlessExperimental: {
+    REQUIRED_ARGS: ['--deterministic-mode', '--enable-begin-frame-control']
+  }
+}))
+
+const puppeteerMock = require('puppeteer-core') // eslint-disable-line @typescript-eslint/no-var-requires
+const mockLaunch = puppeteerMock.default.launch as jest.Mock
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('launch() with no options sets headless shell and required args', async () => {
+  await launch()
+  expect(mockLaunch).toHaveBeenCalledWith({
+    headless: 'shell',
+    args: ['--deterministic-mode', '--enable-begin-frame-control']
+  })
+})
+
+test('launch() merges custom args with required args', async () => {
+  await launch({ args: ['--no-sandbox'] })
+  expect(mockLaunch).toHaveBeenCalledWith({
+    headless: 'shell',
+    args: ['--no-sandbox', '--deterministic-mode', '--enable-begin-frame-control']
+  })
+})
+
+test('launch() overrides headless option to shell', async () => {
+  await launch({ headless: true } as any)
+  expect(mockLaunch).toHaveBeenCalledWith(
+    expect.objectContaining({ headless: 'shell' })
+  )
+})
+
+test('launch() preserves other options', async () => {
+  await launch({ slowMo: 50 })
+  expect(mockLaunch).toHaveBeenCalledWith(
+    expect.objectContaining({ slowMo: 50 })
+  )
+})


### PR DESCRIPTION
## Summary

- Add 70 unit tests across 5 new test files covering pure logic that previously required browser integration tests
- Tests cover: `capture()` factory, `launch()` option merging, `PuppeteerCaptureBase` (constructor validation, attach/detach, start/stop error paths, events, `findFfmpeg()`), `MP4()` format configuration, and `PuppeteerCaptureViaHeadlessExperimental` (`validateBrowserArgs`, constructor platform check, `generateInjector`)
- All tests use mocks — no browser or ffmpeg process required, enabling local testing on macOS

Closes #61

## Test plan

- [x] All 70 new unit tests pass (`npx jest --testPathPattern='...' --verbose`)
- [x] Full project lint passes (`npm run lint`)
- [ ] CI passes on Ubuntu + Windows matrix
- [ ] Existing integration tests remain unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)