### PR TITLE
(chore) add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities via
+[GitHub Security Advisories](https://github.com/alexey-pelykh/puppeteer-capture/security/advisories/new).
+
+Please do NOT file a public issue for security vulnerabilities.


### PR DESCRIPTION
## Summary

- Add `SECURITY.md` with vulnerability reporting instructions directing security researchers to GitHub Security Advisories
- Prevents public disclosure of vulnerabilities via regular issues

Closes #82

## Test plan

- [x] `SECURITY.md` exists at repository root
- [x] Links to correct GitHub Security Advisories URL
- [x] Instructs reporters NOT to file public issues