### PR TITLE
(fix) reverse integration job install ordering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,11 +141,11 @@ jobs:
           path: ${{ steps.pptr-cache.outputs.path }}
           key: puppeteer-${{ runner.os }}-${{ runner.arch }}-${{ matrix.puppeteer-version }}
 
-      - name: Install Puppeteer ${{ matrix.puppeteer-version }}
-        run: npm install 'puppeteer@${{ matrix.puppeteer-version }}' 'puppeteer-core@${{ matrix.puppeteer-version }}'
-
       - name: Install dependencies
         run: npm ci
+
+      - name: Install Puppeteer ${{ matrix.puppeteer-version }}
+        run: npm install --no-save 'puppeteer@${{ matrix.puppeteer-version }}' 'puppeteer-core@${{ matrix.puppeteer-version }}'
 
       - name: Verify the Puppeteer and Puppeteer-Core versions
         run: |


### PR DESCRIPTION
## Summary

- Reverse `npm install` / `npm ci` order in the integration job so `npm ci` runs first (clean lockfile install), then `npm install --no-save` overlays the matrix puppeteer version without modifying the lockfile
- Previously `npm install` ran first to add puppeteer, then `npm ci` nuked `node_modules` and reinstalled from the (potentially stale) lockfile — fragile ordering that depended on `npm install` updating the lockfile correctly

## Test plan

- [ ] Integration matrix passes on all OS × puppeteer-version combinations
- [ ] Verify step still confirms correct puppeteer versions are installed

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)