### PR TITLE
(imp) add Dependabot configuration for GitHub Actions and npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` to enable automated dependency updates
- Configures weekly checks for both `github-actions` and `npm` ecosystems
- Sets `open-pull-requests-limit: 10` for npm to manage PR volume

Closes #83

## Test plan
- [ ] Verify Dependabot picks up the config after merge (GitHub shows Dependabot status in Settings > Code security)
- [ ] Confirm Dependabot creates PRs for outdated dependencies on next weekly run

🤖 Generated with [Claude Code](https://claude.com/claude-code)