### PR TITLE
(fix) typo in setter parameter: dropCaptiuredFrames

### DIFF
--- a/src/PuppeteerCaptureBase.ts
+++ b/src/PuppeteerCaptureBase.ts
@@ -95,8 +95,8 @@ export abstract class PuppeteerCaptureBase extends EventEmitter implements Puppe
     return this._dropCapturedFrames
   }
 
-  public set dropCapturedFrames (dropCaptiuredFrames: boolean) {
-    this._dropCapturedFrames = dropCaptiuredFrames
+  public set dropCapturedFrames (value: boolean) {
+    this._dropCapturedFrames = value
   }
 
   public get recordedFrames (): number {


### PR DESCRIPTION
## Summary
- Fix typo in `PuppeteerCaptureBase.ts` setter parameter name: `dropCaptiuredFrames` → `value` (extra `i` removed, using standard setter pattern)

Closes #76

## Test plan
- [x] Lint passes (`npm run lint`)
- [x] Unit tests pass (`PuppeteerCaptureBase.test.ts` — setter coverage via `dropCapturedFrames` describe block)

🤖 Generated with [Claude Code](https://claude.com/claude-code)