### PR TITLE
(imp) add types field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "video recorder"
   ],
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "dependencies": {
     "async-mutex": "^0.5.0",
     "fluent-ffmpeg": "^2.1.3",


### PR DESCRIPTION
## Summary
- Add explicit `"types": "lib/index.d.ts"` field to `package.json`
- Improves type resolution discoverability for TypeScript consumers across all module resolution modes

Closes #74

## Test plan
- [x] Lint passes (`npm run lint`)
- [x] Build succeeds and `lib/index.d.ts` is generated
- [x] CI validates on Ubuntu + Windows, Node LTS iron + jod

🤖 Generated with [Claude Code](https://claude.com/claude-code)