### PR TITLE
(fix) reject fps === 0 to prevent Infinity interval

### DIFF
--- a/src/PuppeteerCaptureBase.test.ts
+++ b/src/PuppeteerCaptureBase.test.ts
@@ -124,9 +124,10 @@ describe('constructor', () => {
     )
   })
 
-  test('accepts fps of 0', () => {
-    const capture = new TestCapture({ fps: 0 })
-    expect(capture['_frameInterval']).toBe(Infinity) // eslint-disable-line @typescript-eslint/dot-notation
+  test('throws when fps is zero', () => {
+    expect(() => new TestCapture({ fps: 0 })).toThrow(
+      'options.fps can not be set to 0'
+    )
   })
 })
 

--- a/src/PuppeteerCaptureBase.ts
+++ b/src/PuppeteerCaptureBase.ts
@@ -52,7 +52,7 @@ export abstract class PuppeteerCaptureBase extends EventEmitter implements Puppe
     if (this._options.fps == null) {
       throw new Error('options.fps needs to be set')
     }
-    if (this._options.fps < 0) {
+    if (this._options.fps <= 0) {
       throw new Error(`options.fps can not be set to ${this._options.fps}`)
     }
     this._frameInterval = 1000.0 / this._options.fps


### PR DESCRIPTION
## Summary

- Change `fps < 0` guard to `fps <= 0` in constructor validation to reject zero FPS
- Update test to verify `fps: 0` now throws instead of being accepted

When `fps === 0`, the frame interval becomes `1000.0 / 0 = Infinity`, and `inputFPS(0)` causes ffmpeg errors.

Closes #77

## Test plan

- [x] Existing test updated: `'throws when fps is zero'` verifies `new PuppeteerCapture({ fps: 0 })` throws
- [x] Existing `'throws when fps is negative'` test still passes
- [ ] CI passes on Ubuntu and Windows matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)