### PR TITLE
(fix) reverse integration job install ordering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,11 +141,11 @@ jobs:
           path: ${{ steps.pptr-cache.outputs.path }}
           key: puppeteer-${{ runner.os }}-${{ runner.arch }}-${{ matrix.puppeteer-version }}
 
-      - name: Install Puppeteer ${{ matrix.puppeteer-version }}
-        run: npm install 'puppeteer@${{ matrix.puppeteer-version }}' 'puppeteer-core@${{ matrix.puppeteer-version }}'
-
       - name: Install dependencies
         run: npm ci
+
+      - name: Install Puppeteer ${{ matrix.puppeteer-version }}
+        run: npm install --no-save 'puppeteer@${{ matrix.puppeteer-version }}' 'puppeteer-core@${{ matrix.puppeteer-version }}'
 
       - name: Verify the Puppeteer and Puppeteer-Core versions
         run: |


### PR DESCRIPTION
## Summary
- Reverse the install order in the integration CI job: run `npm ci` first, then overlay the matrix puppeteer version with `npm install --no-save`
- Previously `npm install` ran before `npm ci`, which was fragile because `npm ci` deletes `node_modules` entirely and reinstalls from the lockfile, potentially wiping out the puppeteer version just installed

## Test plan
- [ ] CI integration matrix passes with the new ordering
- [ ] Puppeteer version verification step confirms correct versions are installed

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)