### PR TITLE
(imp) add Dependabot configuration for GitHub Actions and npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` with weekly update checks for GitHub Actions and npm ecosystems
- GitHub Actions ecosystem: weekly schedule, default PR limit
- npm ecosystem: weekly schedule, 10 open PR limit

Closes #83

## Test plan
- [ ] Verify Dependabot picks up the configuration and starts monitoring dependencies
- [ ] Confirm PRs are created for outdated GitHub Actions and npm packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)