### PR TITLE
(fix) typo in setter parameter: dropCaptiuredFrames

### DIFF
--- a/src/PuppeteerCaptureBase.ts
+++ b/src/PuppeteerCaptureBase.ts
@@ -95,8 +95,8 @@ export abstract class PuppeteerCaptureBase extends EventEmitter implements Puppe
     return this._dropCapturedFrames
   }
 
-  public set dropCapturedFrames (dropCaptiuredFrames: boolean) {
-    this._dropCapturedFrames = dropCaptiuredFrames
+  public set dropCapturedFrames (dropCapturedFrames: boolean) {
+    this._dropCapturedFrames = dropCapturedFrames
   }
 
   public get recordedFrames (): number {


### PR DESCRIPTION
## Summary
- Fixed typo in `PuppeteerCaptureBase.ts` setter parameter: `dropCaptiuredFrames` → `dropCapturedFrames` (extra "i" in "Captiured")

## Test plan
- [x] Lint passes (`npm run lint`)
- [x] Build passes (`npm run build`)
- [x] Unit tests pass (macOS-incompatible integration tests excluded per platform constraints)

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)