### PR TITLE
(chore) add SPDX license headers to all source files

### DIFF
--- a/src/MissingHeadlessExperimentalRequiredArgs.ts
+++ b/src/MissingHeadlessExperimentalRequiredArgs.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022-2026 Alexey Pelykh
+
 import { PuppeteerCaptureViaHeadlessExperimental } from './PuppeteerCaptureViaHeadlessExperimental'
 
 export class MissingHeadlessExperimentalRequiredArgs extends Error {

--- a/src/NotChromeHeadlessShell.ts
+++ b/src/NotChromeHeadlessShell.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022-2026 Alexey Pelykh
+
 export class NotChromeHeadlessShell extends Error {
   constructor (executablePath: string) {
     super('Not chrome-headless-shell: ' + executablePath)

--- a/src/PuppeteerCapture.ts
+++ b/src/PuppeteerCapture.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022-2026 Alexey Pelykh
+
 import type { Page as PuppeteerPage } from 'puppeteer-core'
 import { Writable } from 'stream'
 import { PuppeteerCaptureEvents } from './PuppeteerCaptureEvents'

--- a/src/PuppeteerCaptureBase.test.ts
+++ b/src/PuppeteerCaptureBase.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022-2026 Alexey Pelykh
+
 import { PassThrough } from 'stream'
 import { PuppeteerCaptureBase } from './PuppeteerCaptureBase'
 

--- a/src/PuppeteerCaptureBase.ts
+++ b/src/PuppeteerCaptureBase.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022-2026 Alexey Pelykh
+
 import { Mutex } from 'async-mutex'
 import ffmpeg, { FfmpegCommand, setFfmpegPath } from 'fluent-ffmpeg'
 import { mkdir } from 'fs/promises'

--- a/src/PuppeteerCaptureEvents.ts
+++ b/src/PuppeteerCaptureEvents.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022-2026 Alexey Pelykh
+
 export interface PuppeteerCaptureEvents {
   captureStarted: () => void
   frameCaptured: (index: number, timestamp: number, data: Buffer) => void

--- a/src/PuppeteerCaptureFormat.test.ts
+++ b/src/PuppeteerCaptureFormat.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022-2026 Alexey Pelykh
+
 import { MP4 } from './PuppeteerCaptureFormat'
 
 function createMockFfmpegCommand (): any {

--- a/src/PuppeteerCaptureFormat.ts
+++ b/src/PuppeteerCaptureFormat.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022-2026 Alexey Pelykh
+
 import { FfmpegCommand } from 'fluent-ffmpeg'
 
 export function MP4 (

--- a/src/PuppeteerCaptureOptions.ts
+++ b/src/PuppeteerCaptureOptions.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022-2026 Alexey Pelykh
+
 import { FfmpegCommand } from 'fluent-ffmpeg'
 
 export interface PuppeteerCaptureOptions {

--- a/src/PuppeteerCaptureStartOptions.ts
+++ b/src/PuppeteerCaptureStartOptions.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022-2026 Alexey Pelykh
+
 export interface PuppeteerCaptureStartOptions {
   waitForFirstFrame?: boolean
   dropCapturedFrames?: boolean

--- a/src/PuppeteerCaptureViaHeadlessExperimental.test.ts
+++ b/src/PuppeteerCaptureViaHeadlessExperimental.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022-2026 Alexey Pelykh
+
 import { setTimeout } from 'node:timers/promises'
 import { executablePath } from 'puppeteer'
 import type { Browser as PuppeteerBrowser } from 'puppeteer-core'

--- a/src/PuppeteerCaptureViaHeadlessExperimental.ts
+++ b/src/PuppeteerCaptureViaHeadlessExperimental.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022-2026 Alexey Pelykh
+
 import { Protocol } from 'devtools-protocol'
 import type {
   Browser as PuppeteerBrowser,

--- a/src/PuppeteerCaptureViaHeadlessExperimental.unit.test.ts
+++ b/src/PuppeteerCaptureViaHeadlessExperimental.unit.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022-2026 Alexey Pelykh
+
 import { MissingHeadlessExperimentalRequiredArgs } from './MissingHeadlessExperimentalRequiredArgs'
 import { NotChromeHeadlessShell } from './NotChromeHeadlessShell'
 import { PuppeteerCaptureViaHeadlessExperimental } from './PuppeteerCaptureViaHeadlessExperimental'

--- a/src/capture.test.ts
+++ b/src/capture.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022-2026 Alexey Pelykh
+
 import { capture } from './capture'
 
 const mockAttach = jest.fn()

--- a/src/capture.ts
+++ b/src/capture.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022-2026 Alexey Pelykh
+
 import type { Page as PuppeteerPage } from 'puppeteer-core'
 import { PuppeteerCapture } from './PuppeteerCapture'
 import { PuppeteerCaptureOptions } from './PuppeteerCaptureOptions'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022-2026 Alexey Pelykh
+
 export { capture } from './capture'
 export { launch } from './launch'
 export { MissingHeadlessExperimentalRequiredArgs as MissingRequiredArgs } from './MissingHeadlessExperimentalRequiredArgs'

--- a/src/launch.test.ts
+++ b/src/launch.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022-2026 Alexey Pelykh
+
 import { launch } from './launch'
 
 jest.mock('puppeteer-core', () => ({

--- a/src/launch.ts
+++ b/src/launch.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2022-2026 Alexey Pelykh
+
 import type {
   Browser as PuppeteerBrowser,
   LaunchOptions as PuppeteerLaunchOptions


### PR DESCRIPTION
## Summary

- Add `// SPDX-License-Identifier: MIT` and `// Copyright (c) 2022-2026 Alexey Pelykh` headers to all 18 TypeScript source files in `src/`
- Covers all 12 production files and 6 test files

Closes #79

## Test plan

- [x] `npm run lint` passes
- [x] `npm run build` compiles without errors
- [x] Unit tests pass (70/70)
- [ ] CI passes on Ubuntu and Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)