### PR TITLE
(imp) puppeteer v24.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           - lts/jod
 
     env:
-      PUPPETEER_VERSION: 24.8.2
+      PUPPETEER_VERSION: 24.9.0
 
     steps:
 
@@ -109,6 +109,7 @@ jobs:
           - '24.7.2'
           - '24.8.1'
           - '24.8.2'
+          - '24.9.0'
 
     steps:
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 15
 
     env:
-      PUPPETEER_VERSION: 24.8.2
+      PUPPETEER_VERSION: 24.9.0
 
     steps:
 
@@ -80,7 +80,7 @@ jobs:
       id-token: write
 
     env:
-      PUPPETEER_VERSION: 24.8.2
+      PUPPETEER_VERSION: 24.9.0
 
     steps:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,8 @@
         "@types/which": "^3.0.4",
         "@types/ws": "^8.5.13",
         "jest": "^29.7.0",
-        "puppeteer": "24.8.2",
-        "puppeteer-core": "24.8.2",
+        "puppeteer": "24.9.0",
+        "puppeteer-core": "24.9.0",
         "rimraf": "^6.0.1",
         "ts-jest": "^29.2.5",
         "ts-standard": "^12.0.2",
@@ -35,7 +35,7 @@
         "ffmpeg-static": "^5.2.0"
       },
       "peerDependencies": {
-        "puppeteer-core": "^24.3.0 || ^24.4.0 || ^24.5.0 || ^24.6.0 || ^24.7.0 || ^24.8.0"
+        "puppeteer-core": "^24.3.0 || ^24.4.0 || ^24.5.0 || ^24.6.0 || ^24.7.0 || ^24.8.0 || ^24.9.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1115,17 +1115,17 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.10.4",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.4.tgz",
-      "integrity": "sha512-9DxbZx+XGMNdjBynIs4BRSz+M3iRDeB7qRcAr6UORFLphCIM2x3DXgOucvADiifcqCE4XePFUKcnaAMyGbrDlQ==",
+      "version": "2.10.5",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.5.tgz",
+      "integrity": "sha512-eifa0o+i8dERnngJwKrfp3dEq7ia5XFyoqB17S4gK8GhsQE4/P8nxOfQSE0zQHxzzLo/cmF+7+ywEQ7wK7Fb+w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "debug": "^4.4.0",
+        "debug": "^4.4.1",
         "extract-zip": "^2.0.1",
         "progress": "^2.0.3",
         "proxy-agent": "^6.5.0",
-        "semver": "^7.7.1",
+        "semver": "^7.7.2",
         "tar-fs": "^3.0.8",
         "yargs": "^17.7.2"
       },
@@ -2737,9 +2737,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -7066,19 +7066,19 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "24.8.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.8.2.tgz",
-      "integrity": "sha512-Sn6SBPwJ6ASFvQ7knQkR+yG7pcmr4LfXzmoVp3NR0xXyBbPhJa8a8ybtb6fnw1g/DD/2t34//yirubVczko37w==",
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.9.0.tgz",
+      "integrity": "sha512-L0pOtALIx8rgDt24Y+COm8X52v78gNtBOW6EmUcEPci0TYD72SAuaXKqasRIx4JXxmg2Tkw5ySKcpPOwN8xXnQ==",
       "deprecated": "< 24.15.0 is no longer supported",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.10.4",
+        "@puppeteer/browsers": "2.10.5",
         "chromium-bidi": "5.1.0",
         "cosmiconfig": "^9.0.0",
         "devtools-protocol": "0.0.1439962",
-        "puppeteer-core": "24.8.2",
+        "puppeteer-core": "24.9.0",
         "typed-query-selector": "^2.12.0"
       },
       "bin": {
@@ -7089,15 +7089,15 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.8.2",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.8.2.tgz",
-      "integrity": "sha512-wNw5cRZOHiFibWc0vdYCYO92QuKTbJ8frXiUfOq/UGJWMqhPoBThTKkV+dJ99YyWfzJ2CfQQ4T1nhhR0h8FlVw==",
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.9.0.tgz",
+      "integrity": "sha512-HFdCeH/wx6QPz8EncafbCqJBqaCG1ENW75xg3cLFMRUoqZDgByT6HSueiumetT2uClZxwqj0qS4qMVZwLHRHHw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.10.4",
+        "@puppeteer/browsers": "2.10.5",
         "chromium-bidi": "5.1.0",
-        "debug": "^4.4.0",
+        "debug": "^4.4.1",
         "devtools-protocol": "0.0.1439962",
         "typed-query-selector": "^2.12.0",
         "ws": "^8.18.2"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ffmpeg-static": "^5.2.0"
   },
   "peerDependencies": {
-    "puppeteer-core": "^24.3.0 || ^24.4.0 || ^24.5.0 || ^24.6.0 || ^24.7.0 || ^24.8.0"
+    "puppeteer-core": "^24.3.0 || ^24.4.0 || ^24.5.0 || ^24.6.0 || ^24.7.0 || ^24.8.0 || ^24.9.0"
   },
   "devDependencies": {
     "@types/fluent-ffmpeg": "^2.1.27",
@@ -57,8 +57,8 @@
     "@types/which": "^3.0.4",
     "@types/ws": "^8.5.13",
     "jest": "^29.7.0",
-    "puppeteer": "24.8.2",
-    "puppeteer-core": "24.8.2",
+    "puppeteer": "24.9.0",
+    "puppeteer-core": "24.9.0",
     "rimraf": "^6.0.1",
     "ts-jest": "^29.2.5",
     "ts-standard": "^12.0.2",


### PR DESCRIPTION
## Summary
* Bump puppeteer and puppeteer-core to v24.9.0 (devDependencies)
* Add `|| ^24.9.0` to peerDependencies (minor bump)
* Update CI/publish `PUPPETEER_VERSION` env vars
* Add 24.9.0 to integration test matrix

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)