### PR TITLE
(imp) puppeteer v24.10.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           - lts/jod
 
     env:
-      PUPPETEER_VERSION: 24.9.0
+      PUPPETEER_VERSION: 24.10.2
 
     steps:
 
@@ -110,6 +110,9 @@ jobs:
           - '24.8.1'
           - '24.8.2'
           - '24.9.0'
+          - '24.10.0'
+          - '24.10.1'
+          - '24.10.2'
 
     steps:
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 15
 
     env:
-      PUPPETEER_VERSION: 24.9.0
+      PUPPETEER_VERSION: 24.10.2
 
     steps:
 
@@ -80,7 +80,7 @@ jobs:
       id-token: write
 
     env:
-      PUPPETEER_VERSION: 24.9.0
+      PUPPETEER_VERSION: 24.10.2
 
     steps:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,8 @@
         "@types/which": "^3.0.4",
         "@types/ws": "^8.5.13",
         "jest": "^29.7.0",
-        "puppeteer": "24.9.0",
-        "puppeteer-core": "24.9.0",
+        "puppeteer": "24.10.2",
+        "puppeteer-core": "24.10.2",
         "rimraf": "^6.0.1",
         "ts-jest": "^29.2.5",
         "ts-standard": "^12.0.2",
@@ -35,7 +35,7 @@
         "ffmpeg-static": "^5.2.0"
       },
       "peerDependencies": {
-        "puppeteer-core": "^24.3.0 || ^24.4.0 || ^24.5.0 || ^24.6.0 || ^24.7.0 || ^24.8.0 || ^24.9.0"
+        "puppeteer-core": "^24.3.0 || ^24.4.0 || ^24.5.0 || ^24.6.0 || ^24.7.0 || ^24.8.0 || ^24.9.0 || ^24.10.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2848,9 +2848,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1439962",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1439962.tgz",
-      "integrity": "sha512-jJF48UdryzKiWhJ1bLKr7BFWUQCEIT5uCNbDLqkQJBtkFxYzILJH44WN0PDKMIlGDN7Utb8vyUY85C3w4R/t2g==",
+      "version": "0.0.1452169",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1452169.tgz",
+      "integrity": "sha512-FOFDVMGrAUNp0dDKsAU1TorWJUx2JOU1k9xdgBKKJF3IBh/Uhl2yswG5r3TEAOrCiGY2QRp1e6LVDQrCsTKO4g==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -7066,9 +7066,9 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.9.0.tgz",
-      "integrity": "sha512-L0pOtALIx8rgDt24Y+COm8X52v78gNtBOW6EmUcEPci0TYD72SAuaXKqasRIx4JXxmg2Tkw5ySKcpPOwN8xXnQ==",
+      "version": "24.10.2",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.10.2.tgz",
+      "integrity": "sha512-+k26rCz6akFZntx0hqUoFjCojgOLIxZs6p2k53LmEicwsT8F/FMBKfRfiBw1sitjiCvlR/15K7lBqfjXa251FA==",
       "deprecated": "< 24.15.0 is no longer supported",
       "dev": true,
       "hasInstallScript": true,
@@ -7077,8 +7077,8 @@
         "@puppeteer/browsers": "2.10.5",
         "chromium-bidi": "5.1.0",
         "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1439962",
-        "puppeteer-core": "24.9.0",
+        "devtools-protocol": "0.0.1452169",
+        "puppeteer-core": "24.10.2",
         "typed-query-selector": "^2.12.0"
       },
       "bin": {
@@ -7089,16 +7089,16 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.9.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.9.0.tgz",
-      "integrity": "sha512-HFdCeH/wx6QPz8EncafbCqJBqaCG1ENW75xg3cLFMRUoqZDgByT6HSueiumetT2uClZxwqj0qS4qMVZwLHRHHw==",
+      "version": "24.10.2",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.10.2.tgz",
+      "integrity": "sha512-CnzhOgrZj8DvkDqI+Yx+9or33i3Y9uUYbKyYpP4C13jWwXx/keQ38RMTMmxuLCWQlxjZrOH0Foq7P2fGP7adDQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "2.10.5",
         "chromium-bidi": "5.1.0",
         "debug": "^4.4.1",
-        "devtools-protocol": "0.0.1439962",
+        "devtools-protocol": "0.0.1452169",
         "typed-query-selector": "^2.12.0",
         "ws": "^8.18.2"
       },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ffmpeg-static": "^5.2.0"
   },
   "peerDependencies": {
-    "puppeteer-core": "^24.3.0 || ^24.4.0 || ^24.5.0 || ^24.6.0 || ^24.7.0 || ^24.8.0 || ^24.9.0"
+    "puppeteer-core": "^24.3.0 || ^24.4.0 || ^24.5.0 || ^24.6.0 || ^24.7.0 || ^24.8.0 || ^24.9.0 || ^24.10.0"
   },
   "devDependencies": {
     "@types/fluent-ffmpeg": "^2.1.27",
@@ -57,8 +57,8 @@
     "@types/which": "^3.0.4",
     "@types/ws": "^8.5.13",
     "jest": "^29.7.0",
-    "puppeteer": "24.9.0",
-    "puppeteer-core": "24.9.0",
+    "puppeteer": "24.10.2",
+    "puppeteer-core": "24.10.2",
     "rimraf": "^6.0.1",
     "ts-jest": "^29.2.5",
     "ts-standard": "^12.0.2",


### PR DESCRIPTION
## Summary
* Bump `puppeteer` and `puppeteer-core` devDependencies to 24.10.2
* Add `|| ^24.10.0` to peerDependencies range
* Add 24.10.0, 24.10.1, 24.10.2 to CI integration test matrix
* Update `PUPPETEER_VERSION` env in CI and publish workflows

Closes #130

**Full Changelog**: https://github.com/alexey-pelykh/puppeteer-capture/compare/0d9d6fe...imp/puppeteer-v24.10.2