### PR TITLE
(imp) puppeteer v24.12.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           - lts/jod
 
     env:
-      PUPPETEER_VERSION: 24.11.2
+      PUPPETEER_VERSION: 24.12.1
 
     steps:
 
@@ -116,6 +116,8 @@ jobs:
           - '24.11.0'
           - '24.11.1'
           - '24.11.2'
+          - '24.12.0'
+          - '24.12.1'
 
     steps:
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 15
 
     env:
-      PUPPETEER_VERSION: 24.11.2
+      PUPPETEER_VERSION: 24.12.1
 
     steps:
 
@@ -80,7 +80,7 @@ jobs:
       id-token: write
 
     env:
-      PUPPETEER_VERSION: 24.11.2
+      PUPPETEER_VERSION: 24.12.1
 
     steps:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,8 @@
         "@types/which": "^3.0.4",
         "@types/ws": "^8.5.13",
         "jest": "^29.7.0",
-        "puppeteer": "24.11.2",
-        "puppeteer-core": "24.11.2",
+        "puppeteer": "24.12.1",
+        "puppeteer-core": "24.12.1",
         "rimraf": "^6.0.1",
         "ts-jest": "^29.2.5",
         "ts-standard": "^12.0.2",
@@ -35,7 +35,7 @@
         "ffmpeg-static": "^5.2.0"
       },
       "peerDependencies": {
-        "puppeteer-core": "^24.3.0 || ^24.4.0 || ^24.5.0 || ^24.6.0 || ^24.7.0 || ^24.8.0 || ^24.9.0 || ^24.10.0 || ^24.11.0"
+        "puppeteer-core": "^24.3.0 || ^24.4.0 || ^24.5.0 || ^24.6.0 || ^24.7.0 || ^24.8.0 || ^24.9.0 || ^24.10.0 || ^24.11.0 || ^24.12.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -7066,9 +7066,9 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "24.11.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.11.2.tgz",
-      "integrity": "sha512-HopdRZWHa5zk0HSwd8hU+GlahQ3fmesTAqMIDHVY9HasCvppcYuHYXyjml0nlm+nbwVCqAQWV+dSmiNCrZGTGQ==",
+      "version": "24.12.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.12.1.tgz",
+      "integrity": "sha512-+vvwl+Xo4z5uXLLHG+XW8uXnUXQ62oY6KU6bEFZJvHWLutbmv5dw9A/jcMQ0fqpQdLydHmK0Uy7/9Ilj8ufwSQ==",
       "deprecated": "< 24.15.0 is no longer supported",
       "dev": true,
       "hasInstallScript": true,
@@ -7078,7 +7078,7 @@
         "chromium-bidi": "5.1.0",
         "cosmiconfig": "^9.0.0",
         "devtools-protocol": "0.0.1464554",
-        "puppeteer-core": "24.11.2",
+        "puppeteer-core": "24.12.1",
         "typed-query-selector": "^2.12.0"
       },
       "bin": {
@@ -7089,9 +7089,9 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.11.2",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.11.2.tgz",
-      "integrity": "sha512-c49WifNb8hix+gQH17TldmD6TC/Md2HBaTJLHexIUq4sZvo2pyHY/Pp25qFQjibksBu/SJRYUY7JsoaepNbiRA==",
+      "version": "24.12.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.12.1.tgz",
+      "integrity": "sha512-8odp6d3ERKBa3BAVaYWXn95UxQv3sxvP1reD+xZamaX6ed8nCykhwlOiHSaHR9t/MtmIB+rJmNencI6Zy4Gxvg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ffmpeg-static": "^5.2.0"
   },
   "peerDependencies": {
-    "puppeteer-core": "^24.3.0 || ^24.4.0 || ^24.5.0 || ^24.6.0 || ^24.7.0 || ^24.8.0 || ^24.9.0 || ^24.10.0 || ^24.11.0"
+    "puppeteer-core": "^24.3.0 || ^24.4.0 || ^24.5.0 || ^24.6.0 || ^24.7.0 || ^24.8.0 || ^24.9.0 || ^24.10.0 || ^24.11.0 || ^24.12.0"
   },
   "devDependencies": {
     "@types/fluent-ffmpeg": "^2.1.27",
@@ -57,8 +57,8 @@
     "@types/which": "^3.0.4",
     "@types/ws": "^8.5.13",
     "jest": "^29.7.0",
-    "puppeteer": "24.11.2",
-    "puppeteer-core": "24.11.2",
+    "puppeteer": "24.12.1",
+    "puppeteer-core": "24.12.1",
     "rimraf": "^6.0.1",
     "ts-jest": "^29.2.5",
     "ts-standard": "^12.0.2",


### PR DESCRIPTION
## Summary
* Bump `puppeteer` and `puppeteer-core` devDependencies to 24.12.1
* Add `|| ^24.12.0` to peerDependencies range
* Add 24.12.0 and 24.12.1 to CI integration test matrix
* Update `PUPPETEER_VERSION` env in CI and publish workflows

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)