### PR TITLE
(docs) bump-puppeteer: support (major, minor) bumps

### DIFF
--- a/.claude/commands/bump-puppeteer.md
+++ b/.claude/commands/bump-puppeteer.md
@@ -1,7 +1,7 @@
 # Bump Puppeteer
 
-Discover new puppeteer releases and bump puppeteer-capture to track them. Each new minor gets its own
-commit, PR, merge, and npm release before proceeding to the next.
+Discover new puppeteer releases and bump puppeteer-capture to track them. Each new (major, minor)
+gets its own commit, PR, merge, and npm release before proceeding to the next.
 
 ## Arguments
 
@@ -17,20 +17,21 @@ automatically.
    ```
    npm view puppeteer versions --json
    ```
-3. Filter to versions newer than current, same major
-4. Group by minor version; for each minor, pick the **latest patch**
-5. Order the resulting list by minor ascending
+3. Filter to versions newer than current (across all majors)
+4. Group by (major, minor); for each combo, pick the **latest patch**
+5. Order ascending by major, then by minor — pending minors of the current major exhaust before
+   crossing into the next major. Never skip intermediates.
 
 **If argument was provided**: validate it exists on npm and use only that version.
 
 Present the bump plan and ask for confirmation:
 
 ```
-Current: 24.39.1
+Current: 24.43.1
 
 Pending bumps (one commit + release each):
-  1. 24.40.x -> 24.40.2  (minor bump)
-  2. 24.41.x -> 24.41.0  (minor bump)
+  1. 24.44.x -> 24.44.0  (minor bump)
+  2. 25.0.x  -> 25.0.2   (major bump)
 
 Proceed?
 ```
@@ -63,8 +64,9 @@ All changes go into a single atomic commit.
 ```
 
 **peerDependencies** (`puppeteer-core` field) -- depends on bump type:
-- **Minor bump** (minor number differs from current): append ` || ^{MAJOR}.{NEW_MINOR}.0`
-- **Patch bump** (same minor, higher patch): no change (existing `^{MAJOR}.{MINOR}.0` covers it)
+- **Major bump** (major number differs from current): append ` || ^{NEW_MAJOR}.{NEW_MINOR}.0`
+- **Minor bump** (same major, higher minor): append ` || ^{MAJOR}.{NEW_MINOR}.0`
+- **Patch bump** (same major+minor, higher patch): no change (existing `^{MAJOR}.{MINOR}.0` covers it)
 
 #### `.github/workflows/ci.yml`
 
@@ -105,7 +107,7 @@ Create PR with `gh pr create`:
   ```
   ## Summary
   * Bump puppeteer and puppeteer-core from {OLD_VERSION} to {VERSION}
-  * [If minor bump] Add `^{MAJOR}.{NEW_MINOR}.0` to peerDependencies range
+  * [If minor or major bump] Add `^{MAJOR}.{NEW_MINOR}.0` to peerDependencies range
   * Add {VERSION} to CI integration test matrix
 
   ## Test plan
@@ -157,7 +159,7 @@ Wait for it to complete successfully. If it fails, diagnose and fix before proce
 
 ### Step 2.8: Next version
 
-If more versions remain in the plan, return to **Step 2.1** for the next minor.
+If more versions remain in the plan, return to **Step 2.1** for the next (major, minor).
 
 Clean up the local branch:
 ```bash
@@ -166,13 +168,14 @@ git branch -d imp/puppeteer-v{VERSION}
 
 ## Rules
 
-- **One minor at a time**: never skip intermediate minors (24.39 -> 24.41 MUST go through 24.40)
-- **Latest patch per minor**: when bumping to a new minor, use the latest available patch
+- **One (major, minor) at a time**: never skip intermediates (24.39 -> 24.41 MUST go through 24.40; 24.43 -> 25.1 MUST go through 25.0)
+- **Minors before majors**: exhaust pending minors of the current major before crossing into the next major
+- **Latest patch per (major, minor)**: when bumping to a new (major, minor), use the latest available patch
 - **4 files, 1 commit**: package.json, package-lock.json, ci.yml, publish.yml -- always all four
 - **Commit message**: `(imp) puppeteer v{VERSION}` -- no issue numbers, no other decoration
 - **Package version**: `package.json` `version` stays `0.0.0` -- npm version comes from the Git tag
 - **Release tag format**: semver with minor increment (e.g., `1.46.0`), never patch or major
-- **peerDeps only on minor bumps**: patch bumps within an already-covered minor don't touch peerDeps
+- **peerDeps on minor or major bumps**: patch bumps within an already-covered (major, minor) don't touch peerDeps
 
 ## Resume
 

--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -12,4 +12,4 @@ See [puppeteer-bump-pattern.md](puppeteer-bump-pattern.md) for the detailed chec
 
 ## Feedback
 
-See [feedback-puppeteer-bump-one-at-a-time.md](feedback-puppeteer-bump-one-at-a-time.md) — one minor version per commit+release, never skip minors
+See [feedback-puppeteer-bump-one-at-a-time.md](feedback-puppeteer-bump-one-at-a-time.md) — one (major, minor) per commit+release, never skip; exhaust current-major minors before crossing majors

--- a/.claude/memory/feedback-puppeteer-bump-one-at-a-time.md
+++ b/.claude/memory/feedback-puppeteer-bump-one-at-a-time.md
@@ -1,11 +1,14 @@
 ---
-name: puppeteer-bump-one-minor-at-a-time
-description: Puppeteer version bumps must be done one minor version at a time, each with its own release
-type: feedback
+name: puppeteer-bump-one-step-at-a-time
+description: "Puppeteer version bumps must be done one (major, minor) at a time, exhausting current-major minors before crossing into the next major; each combo gets its own release"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: d03815fc-0e97-4696-8850-546696e14740
 ---
 
-Puppeteer minor version bumps must be done ONE minor at a time, not jumping across multiple minors in a single commit.
+Puppeteer version bumps must be done ONE (major, minor) combo at a time, not jumping across multiple minors or majors in a single commit. Exhaust all pending minors of the current major before crossing into the next major.
 
-**Why:** Each minor version bump gets its own release on npm. Skipping intermediate minors means missing releases.
+**Why:** Each (major, minor) bump gets its own release on npm. Skipping intermediates means missing releases and obscures which puppeteer change broke compatibility if CI fails downstream.
 
-**How to apply:** When current is 24.37.x and latest is 24.39.x, do: bump to 24.38.0 → commit → release → then bump to 24.39.x → commit → release. Never collapse multiple minors into one commit.
+**How to apply:** When current is 24.43.1 and the only newer version is 25.0.2 (no 24.44+ exists), bump directly to 25.0.2 — that's not skipping, because there's nothing between. When current is 24.37.x and latest is 24.39.x, do: bump to 24.38.0 → commit → release → then bump to 24.39.x → commit → release. When both 24.44.0 and 25.0.2 are pending, do 24.44.0 first (exhaust current major), then 25.0.2. Never collapse multiple (major, minor) combos into one commit.

--- a/.claude/memory/puppeteer-bump-pattern.md
+++ b/.claude/memory/puppeteer-bump-pattern.md
@@ -18,9 +18,10 @@ When a new puppeteer version is released, a single commit updates 4 files.
 "puppeteer-core": "{NEW_VERSION}",
 ```
 
-**peerDependencies** — append new `^major.minor.0` range ONLY if the minor version is new:
+**peerDependencies** — append new `^major.minor.0` range when the (major, minor) combo is new:
 - Patch bump (e.g., 24.6.0 -> 24.6.1): NO peerDependencies change (covered by existing `^24.6.0`)
 - Minor bump (e.g., 24.5.0 -> 24.6.0): ADD `|| ^24.6.0` to the peerDependencies range
+- Major bump (e.g., 24.43.1 -> 25.0.2): ADD `|| ^25.0.0` to the peerDependencies range
 
 ### 2. `.github/workflows/ci.yml`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,18 +133,20 @@ provides deployment protection. Provenance attestation links the published packa
 
 When a new puppeteer version is released, a single atomic commit updates 4 files.
 
-**One minor at a time**: When multiple minor versions are pending (e.g. 24.37 → 24.39), bump one
-minor per commit+release. Never skip intermediate minors. Each minor gets its own commit, push, and
-npm release before proceeding to the next.
+**One (major, minor) at a time**: When multiple (major, minor) combos are pending (e.g. 24.43 → 25.1),
+bump one per commit+release. Never skip intermediates (24.43 → 25.0 → 25.1, not 24.43 → 25.1).
+Exhaust all pending minors of the current major before crossing into the next major. Each
+(major, minor) gets its own commit, push, and npm release before proceeding to the next.
 
 **Commit message**: `(imp) puppeteer v{VERSION}`
 
 ### 1. `package.json`
 
 - **`devDependencies`**: Pin both `puppeteer` and `puppeteer-core` to exact new version (no caret)
-- **`peerDependencies`**: Append `|| ^{major}.{minor}.0` **only on minor bumps**
+- **`peerDependencies`**: Append `|| ^{major}.{minor}.0` on **minor or major bumps**
   - Patch bump (e.g. 24.6.0 → 24.6.1): no peerDeps change (existing `^24.6.0` covers it)
   - Minor bump (e.g. 24.5.0 → 24.6.0): add `|| ^24.6.0`
+  - Major bump (e.g. 24.43.1 → 25.0.2): add `|| ^25.0.0`
 
 ### 2. `.github/workflows/ci.yml`
 


### PR DESCRIPTION
## Summary
* Extend `/bump-puppeteer` discovery to consider all newer versions, not just same-major
* Process one `(major, minor)` at a time, exhausting current-major minors before crossing into the next major; never skip intermediates
* `peerDependencies` rule now fires on **minor or major** bumps (patch within an already-covered combo still no-ops)
* Synchronizes wording across `.claude/commands/bump-puppeteer.md`, project `CLAUDE.md`, and the two derived auto-memory files

## Test plan
- [ ] No code change; CI runs but is informational
- [ ] Spec wording self-consistent across command file, CLAUDE.md, and memory files