### PR TITLE
(imp) typescript v6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "rimraf": "^6.0.1",
         "ts-jest": "^29.2.5",
         "ts-standard": "^12.0.2",
-        "typescript": "^5.7.3"
+        "typescript": "^6.0.3"
       },
       "engines": {
         "node": ">=22.12.0",
@@ -8713,9 +8713,9 @@
       "optional": true
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "rimraf": "^6.0.1",
     "ts-jest": "^29.2.5",
     "ts-standard": "^12.0.2",
-    "typescript": "^5.7.3"
+    "typescript": "^6.0.3"
   },
   "files": [
     "lib/**/*",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,8 @@
 {
   "extends": "./tsconfig.base.json",
   "include": ["src"],
-  "exclude": ["**/*.test.ts"]
+  "exclude": ["**/*.test.ts"],
+  "compilerOptions": {
+    "rootDir": "./src"
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "./tsconfig.base.json"
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  }
 }


### PR DESCRIPTION
## Summary
* Bump `typescript` devDependency from `5.9.3` to `6.0.3`
* TypeScript 6.0 requires two config changes that a plain version bump (#228) can't satisfy on its own:
  * **`tsconfig.build.json`**: add explicit `rootDir: "./src"` — TS6 errors with `TS5011` when the output root is only inferred. `./src` was already the inferred common source dir, so emitted layout under `lib/` is unchanged.
  * **`tsconfig.json`**: add explicit `types: ["jest", "node"]` — under TS6 the ambient `@types/jest`/`@types/node` globals (`test`, `expect`, `describe`, `Buffer`, …) are no longer auto-resolved for the test tsconfig, breaking ts-jest compilation. `@types` for imported modules (fluent-ffmpeg, which, ws) resolve via module resolution and are unaffected.

Supersedes #228 (Dependabot's bare bump, which fails the build without the above).

## Toolchain compatibility
* `ts-standard@12` peer `typescript: "*"` — OK
* `ts-jest@29.4.x` peer `typescript: ">=4.3 <7"` — OK for 6.x

## Verified locally
* `npm run build` — exit 0, `lib/` layout unchanged
* `npm run lint` — exit 0
* `npx tsc --noEmit -p tsconfig.json` — 0 errors (all src + tests)
* `npx jest` — 0 ts-jest compile errors (remaining failures are the documented macOS HeadlessExperimental limitation; CI runs Linux/Windows)

## Test plan
- [ ] CI build passes on Ubuntu and Windows
- [ ] Integration tests pass across the puppeteer matrix